### PR TITLE
Basic console output

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,7 +1,8 @@
 module Main where
 
-import           Lib
+import           Changelog
 import           System.Environment
+import FormatConsole (format)
 
 main :: IO ()
 main = do
@@ -13,5 +14,5 @@ main = do
                            ++ " [old hoogle db path] [new hoogle db path]\n")
      else let [oldVersion, newVersion] = args
           in do
-              cl <- fmap show $  compareModules oldVersion newVersion
-              putStrLn $ show cl
+              cl <- compareModules oldVersion newVersion
+              putStrLn $ format cl

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -16,3 +16,4 @@ main = do
           in do
               cl <- compareModules oldVersion newVersion
               putStrLn $ format cl
+              

--- a/changelog-diff.cabal
+++ b/changelog-diff.cabal
@@ -15,7 +15,7 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Lib
+  exposed-modules:     Changelog, FormatConsole
   build-depends:       base >= 4.7 && < 5
                      , containers >= 0.5.6.2
                      , hoogle

--- a/changelog-diff.cabal
+++ b/changelog-diff.cabal
@@ -16,7 +16,8 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Changelog, FormatConsole
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       QuickCheck >= 2.8.1
+                     , base >= 4.7 && < 5
                      , containers >= 0.5.6.2
                      , hoogle
   default-language:    Haskell2010
@@ -25,7 +26,8 @@ executable changelog-diff-exe
   hs-source-dirs:      app
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-  build-depends:       base
+  build-depends:       QuickCheck >= 2.8.1
+                     , base
                      , changelog-diff
                      , containers >= 0.5.6.2
                      , hoogle
@@ -35,7 +37,8 @@ test-suite changelog-diff-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  build-depends:       base
+  build-depends:       QuickCheck >= 2.8.1
+                     , base
                      , changelog-diff
                      , containers >= 0.5.6.2
                      , hoogle

--- a/src/Changelog.hs
+++ b/src/Changelog.hs
@@ -12,8 +12,8 @@ import qualified Data.Map as M
 import           Data.Monoid ((<>), Monoid)
 import qualified Data.Set as S
 import           Debug.Trace
-import           Debug.Trace
 import qualified Hoogle as H
+import           Test.QuickCheck (Arbitrary(..))
 
 type FunctionSignature = (ModuleName, FunctionName, Type)
 type FunctionName = String
@@ -37,11 +37,27 @@ instance Monoid Changelog where
                               ,clDeleted = clDeleted cl1 <> clDeleted cl2
                               ,clChangedType = clChangedType cl1 <> clChangedType cl2
                               ,clUnchanged = clUnchanged cl1 <> clUnchanged cl2}
+    
+instance Arbitrary Changelog where
+  arbitrary = Changelog 
+                <$> arbitrary 
+                <*> arbitrary 
+                <*> arbitrary 
+                <*> arbitrary
 
 
+insertAdded :: FunctionSignature -> Changelog -> Changelog
 insertAdded v cl = cl {clAdded = v : clAdded cl}
+                      
+insertDeleted :: FunctionSignature -> Changelog -> Changelog
 insertDeleted v cl = cl {clDeleted = v : clDeleted cl}                      
+              
+insertChangedType
+  :: (FunctionSignature, FunctionSignature) -> Changelog -> Changelog
 insertChangedType v cl = cl {clChangedType = v : clChangedType cl}
+                            
+                            
+insertUnchanged :: FunctionSignature -> Changelog -> Changelog
 insertUnchanged v cl = cl {clUnchanged = v : clUnchanged cl}
 
 
@@ -60,7 +76,7 @@ groupByModule (Changelog
 
     step f tup@(m, _, _) z = case m `M.member` z of
                                False -> M.insert m (f tup mempty) z
-                               True -> M.adjust (\cl -> cl {clAdded = tup : clAdded cl}) m z
+                               True -> M.adjust (f tup) m z
 
 
 

--- a/src/Changelog.hs
+++ b/src/Changelog.hs
@@ -2,6 +2,7 @@
 module Changelog
     (compareModules
     ,Changelog(..)
+    ,groupByModule
     ) where
 
 import           Control.Applicative (pure, (<$>), (<*>))

--- a/src/FormatConsole.hs
+++ b/src/FormatConsole.hs
@@ -7,21 +7,33 @@ import qualified Data.Map as M
 
 format :: C.Changelog -> String
 format cl = let m = C.groupByModule cl
-            in unlines $ map (\(mN, cl') ->  mN    
-                                          ++ (clPerModule cl'))
-                             (M.toAscList m)
+                spacer = "\n\n"
+            in intercalate spacer $ 
+               map (\(mN, cl') ->  mN  
+                                ++ (clPerModule cl')
+                                ++ spacer)
+                       (M.toAscList m)
 
 clPerModule :: C.Changelog -> String
-clPerModule cl = sep ++ (intercalate sep $ map sigToString (C.clAdded cl)
-                                                         ++ map sigToString (C.clDeleted cl)
-                                                         ++ map changedTypeSigToString (C.clChangedType cl))
+clPerModule cl = sep ++ intercalate (sep ++ sep) 
+                                    (filter (not . null) 
+                                            [added
+                                            ,deleted
+                                            ,changedType])
   where 
+    added = inter $ map (("+ " ++) . sigToString) (C.clAdded cl)
+    deleted = inter $ map (("- " ++) . sigToString) (C.clDeleted cl)
+    changedType = inter $ map changedTypeSigToString (C.clChangedType cl)
+
     sigToString (_, fN, tN) = fN ++ " :: " ++ tN
     changedTypeSigToString ((_, fN, tN),
-                            (_, _, tN')) = intercalate sep [fN ++ " :: " ++ tN'
-                                                           ,fN ++ " :: " ++ tN']
+                            (_, _, tN')) = let topLine = "~ " ++ fN ++ " :: " ++ tN'
+                                           in  inter [topLine
+                                                     ,(replicate (length topLine - length tN') ' ')
+                                                     ++ tN]
 
-    sep = "\n  "
+    sep = "\n    "
+    inter = intercalate sep
 
 
 

--- a/src/FormatConsole.hs
+++ b/src/FormatConsole.hs
@@ -1,11 +1,27 @@
 module FormatConsole (format) where
 
 import qualified Changelog as C
+import           Data.List (intercalate)
 import qualified Data.Map as M
+
 
 format :: C.Changelog -> String
 format cl = let m = C.groupByModule cl
-            in undefined
+            in unlines $ map (\(mN, cl') ->  mN    
+                                          ++ (clPerModule cl'))
+                             (M.toAscList m)
+
+clPerModule :: C.Changelog -> String
+clPerModule cl = sep ++ (intercalate sep $ map sigToString (C.clAdded cl)
+                                                         ++ map sigToString (C.clDeleted cl)
+                                                         ++ map changedTypeSigToString (C.clChangedType cl))
+  where 
+    sigToString (_, fN, tN) = fN ++ " :: " ++ tN
+    changedTypeSigToString ((_, fN, tN),
+                            (_, _, tN')) = intercalate sep [fN ++ " :: " ++ tN'
+                                                           ,fN ++ " :: " ++ tN']
+
+    sep = "\n  "
 
 
 

--- a/src/FormatConsole.hs
+++ b/src/FormatConsole.hs
@@ -4,7 +4,8 @@ import qualified Changelog as C
 import qualified Data.Map as M
 
 format :: C.Changelog -> String
-format cl = undefined
+format cl = let m = C.groupByModule cl
+            in undefined
 
 
 

--- a/src/FormatConsole.hs
+++ b/src/FormatConsole.hs
@@ -1,0 +1,10 @@
+module FormatConsole (format) where
+
+import qualified Changelog as C
+import qualified Data.Map as M
+
+format :: C.Changelog -> String
+format cl = undefined
+
+
+


### PR DESCRIPTION
Rename Lib to Changelog.
Implement basic console output.

_Example:_

`changelog-diff-exe  cassava.0.1.0.1.hoo  cabalScrapZone/cassava.0.4.4.0.hoo`

outputs:

```
Data.Csv
    + QuoteAll :: Quoting
    + QuoteMinimal :: Quoting
    + QuoteNone :: Quoting
    + encIncludeHeader :: EncodeOptions -> !Bool
    + encUseCrLf :: EncodeOptions -> !Bool
    + encodeDefaultOrderedByName :: [a] -> ByteString
    + encQuoting :: EncodeOptions -> !Quoting
    + encodeDefaultOrderedByNameWith :: EncodeOptions -> [a] -> ByteString
    + headerOrder :: a -> Header
    + header :: [ByteString] -> Header
    + index :: Record -> Int -> Parser a
    + unsafeIndex :: Record -> Int -> Parser a
    + lookup :: NamedRecord -> ByteString -> Parser a

    - EncodeOptions :: {-# UNPACK #-} !Word8 -> EncodeOptions

    ~ encode :: [a] -> ByteString
                Vector a -> ByteString
    ~ encodeWith :: EncodeOptions -> [a] -> ByteString
                    EncodeOptions -> Vector a -> ByteString
    ~ encodeByName :: Header -> [a] -> ByteString
                      Header -> Vector a -> ByteString



Data.Csv.Builder
    + encodeRecord :: a -> Builder
    + encodeDefaultOrderedNamedRecord :: a -> Builder
    + encodeHeader :: Header -> Builder
    + encodeRecordWith :: EncodeOptions -> a -> Builder
    + encodeDefaultOrderedNamedRecordWith :: EncodeOptions -> a -> Builder
    + encodeHeaderWith :: EncodeOptions -> Header -> Builder
    + encodeNamedRecord :: Header -> a -> Builder



Data.Csv.Incremental
    + HasHeader :: HasHeader
    + NoHeader :: HasHeader
    + PartialH :: (ByteString -> HeaderParser a) -> HeaderParser a
    + Done :: [Either String a] -> Parser a
    + encodeDefaultOrderedByName :: NamedBuilder a -> ByteString
    + encode :: Builder a -> ByteString
    + decodeHeader :: HeaderParser ByteString
    + FailH :: !ByteString -> String -> HeaderParser a
    + Fail :: !ByteString -> String -> Parser a
    + Many :: [Either String a] -> (ByteString -> Parser a) -> Parser a
    + encodeRecord :: a -> Builder a
    + DoneH :: !Header -> a -> HeaderParser a
    + encodeNamedRecord :: a -> NamedBuilder a
    + decode :: HasHeader -> Parser a
    + encodeDefaultOrderedByNameWith :: EncodeOptions -> NamedBuilder a -> ByteString
    + encodeWith :: EncodeOptions -> Builder a -> ByteString
    + encodeByName :: Header -> NamedBuilder a -> ByteString
    + decodeHeaderWith :: DecodeOptions -> HeaderParser ByteString
    + decodeWith :: DecodeOptions -> HasHeader -> Parser a



Data.Csv.Parser
    ~ name :: Word8 -> Parser Name
              Word8 -> Parser Field



Data.Csv.Streaming
    + Nil :: (Maybe String) -> ByteString -> Records a
    + Cons :: (Either String a) -> (Records a) -> Records a
    + decode :: HasHeader -> ByteString -> Records a


```
